### PR TITLE
Implemented Tactician CommandBus wrapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "jms/serializer": "^1.1",
     "predis/predis": "^1.0",
     "mongodb/mongodb": "^1.0.0",
-    "doctrine/dbal": "^2.5"
+    "doctrine/dbal": "^2.5",
+    "league/tactician": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/CommandBus/TacticianCommandBus.php
+++ b/src/CommandBus/TacticianCommandBus.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace HelloFresh\Engine\CommandBus;
+
+use League\Tactician\CommandBus;
+use League\Tactician\Handler\CommandHandlerMiddleware;
+use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
+use League\Tactician\Handler\Locator\HandlerLocator;
+use League\Tactician\Handler\Locator\InMemoryLocator;
+use League\Tactician\Handler\MethodNameInflector\HandleInflector;
+use League\Tactician\Middleware;
+use League\Tactician\Plugins\LockingMiddleware;
+
+class TacticianCommandBus implements CommandBusInterface
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+    /**
+     * @var InMemoryLocator
+     */
+    private $commandLocator;
+
+    /**
+     * @param Middleware[]|null $middleware
+     */
+    public function __construct(array $middleware = null)
+    {
+        $this->commandLocator = new InMemoryLocator();
+        $this->commandBus = new CommandBus(
+            $middleware ?: $this->createDefaultMiddlewares($this->commandLocator)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function subscribe($commandName, $handler)
+    {
+        \Assert\that($commandName)->notEmpty()->string();
+
+        $this->commandLocator->addHandler($handler, $commandName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($command)
+    {
+        $this->commandBus->handle($command);
+    }
+
+    /**
+     * Create a default set op middlewares to use within the tactician command bus.
+     *
+     * @param HandlerLocator $commandLocator
+     * @return Middleware[]
+     */
+    public static function createDefaultMiddlewares(HandlerLocator $commandLocator)
+    {
+        return [
+            new LockingMiddleware(),
+            static::createDefaultCommandHandlerMiddleware($commandLocator)
+        ];
+    }
+
+    /**
+     * Create a default command handle middleware for tactician that uses the same convention as SimpleCommandBus.
+     *
+     * @param HandlerLocator $commandLocator
+     * @return Middleware
+     */
+    public static function createDefaultCommandHandlerMiddleware(HandlerLocator $commandLocator)
+    {
+        return new CommandHandlerMiddleware(
+            new ClassNameExtractor(),
+            $commandLocator,
+            new HandleInflector()
+        );
+    }
+}

--- a/tests/CommandBus/TacticianCommandBusTest.php
+++ b/tests/CommandBus/TacticianCommandBusTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\CommandBus;
+
+use Assert\InvalidArgumentException;
+use HelloFresh\Engine\CommandBus\CommandBusInterface;
+use HelloFresh\Engine\CommandBus\TacticianCommandBus;
+use HelloFresh\Tests\Engine\Mock\InvalidHandler;
+use HelloFresh\Tests\Engine\Mock\TestCommand;
+use HelloFresh\Tests\Engine\Mock\TestHandler;
+use League\Tactician\Exception\CanNotInvokeHandlerException;
+use League\Tactician\Exception\MissingHandlerException;
+
+class TacticianCommandBusTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    protected function setUp()
+    {
+        $this->commandBus = new TacticianCommandBus();
+    }
+
+    /**
+     * @test
+     */
+    public function itExecutesAMessage()
+    {
+        $handler = new TestHandler();
+        $this->commandBus->subscribe(TestCommand::class, $handler);
+
+        $command = new TestCommand("hey");
+        $this->commandBus->execute($command);
+        $this->commandBus->execute($command);
+        $this->commandBus->execute($command);
+
+        $this->assertSame(3, $handler->getCounter());
+    }
+
+    /**
+     * @test
+     */
+    public function itFailsWhenThereIsNoHandlers()
+    {
+        $command = new TestCommand("hey");
+        
+        $this->expectException(MissingHandlerException::class);
+        
+        $this->commandBus->execute($command);
+    }
+
+    /**
+     * @test
+     */
+    public function itFailsWhenHaveInvalidSubscriber()
+    {
+        $command = new TestCommand("hey");
+        $handler = new TestHandler();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->commandBus->subscribe($command, $handler);
+    }
+
+    /**
+     * @test
+     */
+    public function itFailsWhenHandlerHasAnInvalidHandleMethod()
+    {
+        $command = new TestCommand("hey");
+        $handler = new InvalidHandler();
+
+        $this->commandBus->subscribe(TestCommand::class, $handler);
+
+        $this->expectException(CanNotInvokeHandlerException::class);
+
+        $this->commandBus->execute($command);
+    }
+}


### PR DESCRIPTION
# What this PR changes:
- This PR adds a tactician wrapper that mirrors the SimpleCommandBus implementation but allows for custom middleware per projects.
# When reviewing, please consider:
- If we should just use Tactician as the default CommandBus and not have our own implementation.
