### PR TITLE
Tactician CommandBus improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "jms/serializer": "^1.1",
     "predis/predis": "^1.0",
     "mongodb/mongodb": "^1.0.0",
-    "doctrine/dbal": "^2.5"
+    "doctrine/dbal": "^2.5",
+    "league/tactician": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/CommandBus/TacticianCommandBus.php
+++ b/src/CommandBus/TacticianCommandBus.php
@@ -2,7 +2,10 @@
 
 namespace HelloFresh\Engine\CommandBus;
 
+use HelloFresh\Engine\CommandBus\Exception\CanNotInvokeHandlerException;
+use HelloFresh\Engine\CommandBus\Exception\MissingHandlerException;
 use League\Tactician\CommandBus;
+use League\Tactician\Exception as TacticianException;
 
 class TacticianCommandBus implements CommandBusInterface
 {
@@ -25,6 +28,12 @@ class TacticianCommandBus implements CommandBusInterface
      */
     public function execute($command)
     {
-        $this->commandBus->handle($command);
+        try {
+            $this->commandBus->handle($command);
+        } catch (TacticianException\MissingHandlerException $e) {
+            throw new MissingHandlerException($e->getMessage(), $e->getCode(), $e);
+        } catch (TacticianException\CanNotInvokeHandlerException $e) {
+            throw new CanNotInvokeHandlerException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/tests/CommandBus/SimpleCommandBusTest.php
+++ b/tests/CommandBus/SimpleCommandBusTest.php
@@ -47,13 +47,10 @@ class SimpleCommandBusTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException \HelloFresh\Engine\CommandBus\Exception\MissingHandlerException
      */
-    public function itLosesMessageWhenThereIsNoHandlers()
+    public function itFailsWhenThereIsNoHandlers()
     {
         $command = new TestCommand("hey");
         $this->commandBus->execute($command);
-
-        $handler = new TestHandler();
-        $this->assertSame(0, $handler->getCounter());
     }
 
     /**
@@ -66,7 +63,6 @@ class SimpleCommandBusTest extends \PHPUnit_Framework_TestCase
         $handler = new TestHandler();
 
         $this->locator->addHandler($command, $handler);
-        $this->commandBus->execute($command);
     }
 
     /**

--- a/tests/CommandBus/TacticianCommandBusTest.php
+++ b/tests/CommandBus/TacticianCommandBusTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\CommandBus;
+
+use HelloFresh\Engine\CommandBus\TacticianCommandBus;
+use HelloFresh\Tests\Engine\Mock\InvalidHandler;
+use HelloFresh\Tests\Engine\Mock\TestCommand;
+use HelloFresh\Tests\Engine\Mock\TestHandler;
+use League\Tactician\CommandBus;
+use League\Tactician\Handler\CommandHandlerMiddleware;
+use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
+use League\Tactician\Handler\Locator\HandlerLocator;
+use League\Tactician\Handler\Locator\InMemoryLocator;
+use League\Tactician\Handler\MethodNameInflector\HandleInflector;
+use League\Tactician\Plugins\LockingMiddleware;
+
+class TacticianCommandBusTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var InMemoryLocator
+     */
+    private $locator;
+    /**
+     * @var CommandBus
+     */
+    private $internalCommandBus;
+    /**
+     * @var TacticianCommandBus
+     */
+    private $commandBus;
+
+    protected function setUp()
+    {
+        $this->locator = new InMemoryLocator();
+        $this->internalCommandBus = self::createASimpleBus($this->locator);
+
+        $this->commandBus = new TacticianCommandBus($this->internalCommandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function itExecutesAMessage()
+    {
+        $handler = new TestHandler();
+        $this->locator->addHandler($handler, TestCommand::class);
+
+        $command = new TestCommand("hey");
+        $this->commandBus->execute($command);
+        $this->commandBus->execute($command);
+        $this->commandBus->execute($command);
+
+        $this->assertSame(3, $handler->getCounter());
+    }
+
+    /**
+     * @test
+     * @expectedException \HelloFresh\Engine\CommandBus\Exception\MissingHandlerException
+     */
+    public function itFailsWhenThereIsNoHandlers()
+    {
+        $command = new TestCommand("hey");
+        $this->commandBus->execute($command);
+
+        $handler = new TestHandler();
+        $this->assertSame(0, $handler->getCounter());
+    }
+
+    /**
+     * @test
+     * @expectedException \HelloFresh\Engine\CommandBus\Exception\CanNotInvokeHandlerException
+     */
+    public function itFailsWhenHandlerHasAnInvalidHandleMethod()
+    {
+        $handler = new InvalidHandler();
+        $this->locator->addHandler($handler, TestCommand::class);
+
+        $command = new TestCommand("hey");
+        $this->commandBus->execute($command);
+    }
+
+    /**
+     * Create a tactician command bus that uses the same convention as SimpleCommandBus.
+     *
+     * @param HandlerLocator $commandLocator
+     * @return CommandBus
+     */
+    public static function createASimpleBus(HandlerLocator $commandLocator)
+    {
+        return new CommandBus([
+            new LockingMiddleware(),
+            new CommandHandlerMiddleware(
+                new ClassNameExtractor(),
+                $commandLocator,
+                new HandleInflector()
+            )
+        ]);
+    }
+}


### PR DESCRIPTION
# What this PR changes:
- Added Tactician CommandBus tests
- Fixed TacticianCommandBus so they thow similar exception as the SimpleCommandBus
# When reviewing, please consider:
- Should we update `HelloFresh\Engine\CommandBus\Exception\MissingHandlerException\InMemoryLocator` to have the same `addHandler` signature as tactician?
