### PR TITLE
Added support for Vector FQCN and Vector as root for deserialization

### DIFF
--- a/src/Serializer/Type/VectorHandler.php
+++ b/src/Serializer/Type/VectorHandler.php
@@ -5,28 +5,42 @@ namespace HelloFresh\Engine\Serializer\Type;
 use Collections\Vector;
 use Collections\VectorInterface;
 use JMS\Serializer\Context;
+use JMS\Serializer\GenericDeserializationVisitor;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\VisitorInterface;
 
 class VectorHandler implements SubscribingHandlerInterface
 {
     public static function getSubscribingMethods()
     {
-        return [
-            [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
-                'format' => 'json',
-                'type' => 'Vector',
-                'method' => 'serializeCollection'
-            ],
-            [
-                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
-                'format' => 'json',
-                'type' => 'Vector',
-                'method' => 'deserializeCollection'
-            ]
+        $formats = ['json', 'xml', 'yml'];
+        $collectionTypes = [
+            'Vector',
+            Vector::class,
         ];
+
+        $methods = [];
+        foreach ($collectionTypes as $type) {
+            foreach ($formats as $format) {
+                $methods[] = [
+                    'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                    'type' => $type,
+                    'format' => $format,
+                    'method' => 'serializeCollection',
+                ];
+
+                $methods[] = [
+                    'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                    'type' => $type,
+                    'format' => $format,
+                    'method' => 'deserializeCollection',
+                ];
+            }
+        }
+
+        return $methods;
     }
 
     public function serializeCollection(
@@ -46,6 +60,24 @@ class VectorHandler implements SubscribingHandlerInterface
         // See above.
         $type['name'] = 'array';
 
+        // When there is not root set for the visitor we need to handle the vector result setting
+        // manually this is related to https://github.com/schmittjoh/serializer/issues/95
+        $isRoot = null === $visitor->getResult();
+        if ($isRoot && $visitor instanceof GenericDeserializationVisitor) {
+            $metadata = new ClassMetadata(Vector::class);
+            $vector = new Vector();
+
+            $visitor->startVisitingObject($metadata, $vector, $type, $context);
+
+            $array = $visitor->visitArray($data, $type, $context);
+            $vector->setAll($array);
+
+            $visitor->endVisitingObject($metadata, $vector, $type, $context);
+
+            return $vector;
+        }
+
+        // No a root so just return the vector
         return new Vector($visitor->visitArray($data, $type, $context));
     }
 }

--- a/tests/Serializer/Type/JMSSerializerHandlerTestCase.php
+++ b/tests/Serializer/Type/JMSSerializerHandlerTestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Serializer\Type;
+
+use JMS\Serializer\SerializerBuilder;
+use PHPUnit\Framework\TestCase;
+use JMS\Serializer\Serializer;
+
+abstract class JMSSerializerHandlerTestCase extends TestCase
+{
+    /**
+     * @var Serializer
+     */
+    protected $serializer;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        $this->serializer = $this->createSerializer();
+    }
+
+    /**
+     * Create a serializer instance.
+     *
+     * @return Serializer
+     */
+    protected function createSerializer()
+    {
+        $builder = new SerializerBuilder();
+        $builder->addDefaultHandlers();
+        $builder->addDefaultDeserializationVisitors();
+        $builder->addDefaultSerializationVisitors();
+        
+        $this->configureBuilder($builder);
+        
+        return $builder->build();
+    }
+
+    /**
+     * Configure the serializer builder for the test case.
+     *
+     * @param SerializerBuilder $builder
+     * @return void
+     */
+    abstract protected function configureBuilder(SerializerBuilder $builder);
+}

--- a/tests/Serializer/Type/VectorHandlerTest.php
+++ b/tests/Serializer/Type/VectorHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Serializer\Type;
+
+use Collections\Vector;
+use HelloFresh\Engine\Serializer\Type\VectorHandler;
+use JMS\Serializer\Handler\HandlerRegistryInterface;
+use JMS\Serializer\SerializerBuilder;
+
+class VectorHandlerTest extends JMSSerializerHandlerTestCase
+{
+    /**
+     * @dataProvider providerTypes
+     * @param string $type
+     */
+    public function testJsonSerializationAndDeserializationRootLevel($type)
+    {
+        $expectedVector = new Vector(['foo', 'bar']);
+        $expectedJson = '["foo", "bar"]';
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $this->serializer->serialize($expectedVector, 'json')
+        );
+
+        $this->assertEquals(
+            $expectedVector,
+            $this->serializer->deserialize($expectedJson, $type, 'json')
+        );
+    }
+
+    /**
+     * @dataProvider providerTypes
+     * @param string $type
+     */
+    public function testJsonSerializationAndDeserializationChildLevel($type)
+    {
+        $expectedVector = [ 'details' => new Vector(['foo', 'bar']) ];
+        $expectedJson = '{ "details": ["foo", "bar"] }';
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $this->serializer->serialize($expectedVector, 'json')
+        );
+
+        $this->assertEquals(
+            $expectedVector,
+            $this->serializer->deserialize($expectedJson, sprintf('array<string,%s>', $type), 'json')
+        );
+    }
+
+    public function providerTypes()
+    {
+        return [
+            ['Vector'],
+            [Vector::class],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configureBuilder(SerializerBuilder $builder)
+    {
+        $builder->configureHandlers(function (HandlerRegistryInterface $registry) {
+            $registry->registerSubscribingHandler(new VectorHandler());
+        });
+    }
+}


### PR DESCRIPTION
# What this PR changes:
- Improve support for Vector serialization by adding FQCN (this is a fix is needed to undo part of https://github.com/hellofresh/carriers-service/pull/84/commits/07fdfbb36dd8cf20c71307ffba07a4d8685d0da7)
- Improve deserialization support for a Vector as root.
