### PR TITLE
Add middleware and pipeline for better processing

### DIFF
--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HelloFresh\Engine\Middleware;
+
+interface MiddlewareInterface
+{
+    /**
+     * @param mixed $passable
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($passable, $next);
+}

--- a/src/Middleware/Pipeline.php
+++ b/src/Middleware/Pipeline.php
@@ -46,9 +46,10 @@ class Pipeline implements PipelineInterface
     }
 
     /**
+     * @param \Closure|null $final
      * @return mixed
      */
-    public function run()
+    public function to(\Closure $final = null)
     {
         // If there's no middleware on the stack then just return the passable
         if (empty($this->stack)) {
@@ -58,15 +59,15 @@ class Pipeline implements PipelineInterface
         // Run the middleware stack and return it's value
         return call_user_func(array_reduce(
             $this->stack->toArray(),
-            $this->layer(),
-            $this->core()
+            $this->each(),
+            $this->initial($final)
         ), $this->passable);
     }
 
     /**
      * @return \Closure
      */
-    protected function layer()
+    protected function each()
     {
         return function($next, $middleware)
         {
@@ -78,13 +79,13 @@ class Pipeline implements PipelineInterface
     }
 
     /**
-     * @return \Closure
+     * @return \Closure|null
      */
-    protected function core()
+    protected function initial(\Closure $final = null)
     {
-        return function($passable)
+        return function($passable) use ($final)
         {
-            return is_callable($passable) ? $passable() : $passable;
+            return is_callable($final) ? call_user_func($final, $passable) : $passable;
         };
     }
 }

--- a/src/Middleware/Pipeline.php
+++ b/src/Middleware/Pipeline.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace HelloFresh\Engine\Middleware;
+
+use Collections\Stack;
+
+class Pipeline implements PipelineInterface
+{
+    /**
+     * @var Stack
+     */
+    protected $stack;
+
+    /**
+     * @var mixed
+     */
+    protected $passable;
+
+    /**
+     * @param array $stack
+     */
+    public function __construct(array $stack = [])
+    {
+        $this->stack = Stack::fromArray($stack);
+    }
+
+    /**
+     * @param mixed $passable
+     * @return MiddlewareStack
+     */
+    public function pass($passable)
+    {
+        $this->passable = $passable;
+
+        return $this;
+    }
+
+    /**
+     * @param MiddlewareInterface $middleware
+     */
+    public function through(MiddlewareInterface $middleware)
+    {
+        $this->stack->push($middleware);
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function run()
+    {
+        // If there's no middleware on the stack then just return the passable
+        if (empty($this->stack)) {
+            return $this->passable;
+        }
+
+        // Run the middleware stack and return it's value
+        return call_user_func(array_reduce(
+            $this->stack->toArray(),
+            $this->layer(),
+            $this->core()
+        ), $this->passable);
+    }
+
+    /**
+     * @return \Closure
+     */
+    protected function layer()
+    {
+        return function($next, $middleware)
+        {
+            return function($passable) use ($next, $middleware)
+            {
+                return $middleware->handle($passable, $next);
+            };
+        };
+    }
+
+    /**
+     * @return \Closure
+     */
+    protected function core()
+    {
+        return function($passable)
+        {
+            return is_callable($passable) ? $passable() : $passable;
+        };
+    }
+}

--- a/src/Middleware/PipelineInterface.php
+++ b/src/Middleware/PipelineInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HelloFresh\Engine\Middleware;
+
+interface PipelineInterface
+{
+    /**
+     * @param mixed $passable
+     */
+    public function pass($passable);
+
+    /**
+     * @param MiddlwareInterface $middleware
+     */
+    public function through(MiddlewareInterface $middleware);
+
+    /**
+     * @return mixed
+     */
+    public function run();
+}

--- a/src/Middleware/PipelineInterface.php
+++ b/src/Middleware/PipelineInterface.php
@@ -15,7 +15,8 @@ interface PipelineInterface
     public function through(MiddlewareInterface $middleware);
 
     /**
+     * @param \Closure|null $final
      * @return mixed
      */
-    public function run();
+    public function to(\Closure $final = null);
 }

--- a/tests/EventDispatcher/EventDispatcherTest.php
+++ b/tests/EventDispatcher/EventDispatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HelloFresh\Tests\Engine\EventBus;
+namespace HelloFresh\Tests\Engine\EventDispatcher;
 
 use HelloFresh\Engine\EventDispatcher\InMemoryDispatcher;
 use HelloFresh\Engine\EventDispatcher\EventDispatcherInterface;

--- a/tests/Middleware/PipelineTest.php
+++ b/tests/Middleware/PipelineTest.php
@@ -14,16 +14,16 @@ class PipelineTest extends \PHPUnit_Framework_TestCase
     {
         $stack = new Pipeline();
 
-        $this->assertEquals('test', $stack->pass('test')->run());
+        $this->assertEquals('test', $stack->pass('test')->to());
     }
 
     public function testMiddlewareProcessesClosure()
     {
         $stack = new Pipeline();
 
-        $this->assertEquals('test', $stack->pass(function() {
-            return 'test';
-        })->run());
+        $this->assertEquals('test', $stack->pass('test')->to(function($passable) {
+            return $passable;
+        }));
     }
 
     public function testPassThroughMiddlware()
@@ -34,7 +34,7 @@ class PipelineTest extends \PHPUnit_Framework_TestCase
             ->through(new BeforeMiddleware)
             ->through(new AfterMiddleware);
 
-        $this->assertEquals('hello world', $stack->run());
+        $this->assertEquals('hello world', $stack->to());
     }
 
     public function testOrderOfMiddlewareDoesntChangeOutput()
@@ -45,7 +45,7 @@ class PipelineTest extends \PHPUnit_Framework_TestCase
             ->through(new AfterMiddleware)
             ->through(new BeforeMiddleware);
 
-        $this->assertEquals('hello world', $stack->run());
+        $this->assertEquals('hello world', $stack->to());
     }
 
     public function testStackConstructedWithMiddleware()
@@ -55,6 +55,6 @@ class PipelineTest extends \PHPUnit_Framework_TestCase
             new AfterMiddleware
         ]);
 
-        $this->assertEquals('hello world', $stack->pass('')->run());
+        $this->assertEquals('hello world', $stack->pass('')->to());
     }
 }

--- a/tests/Middleware/PipelineTest.php
+++ b/tests/Middleware/PipelineTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Middleware;
+
+use HelloFresh\Engine\Middleware\Pipeline;
+use HelloFresh\Tests\Engine\Mock\BeforeMiddleware;
+use HelloFresh\Tests\Engine\Mock\AfterMiddleware;
+use Prophecy\Prophet;
+use Prophecy\Argument;
+
+class PipelineTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNoMiddlewareReturnsTheSame()
+    {
+        $stack = new Pipeline();
+
+        $this->assertEquals('test', $stack->pass('test')->run());
+    }
+
+    public function testMiddlewareProcessesClosure()
+    {
+        $stack = new Pipeline();
+
+        $this->assertEquals('test', $stack->pass(function() {
+            return 'test';
+        })->run());
+    }
+
+    public function testPassThroughMiddlware()
+    {
+        $stack = new Pipeline();
+
+        $stack->pass('')
+            ->through(new BeforeMiddleware)
+            ->through(new AfterMiddleware);
+
+        $this->assertEquals('hello world', $stack->run());
+    }
+
+    public function testOrderOfMiddlewareDoesntChangeOutput()
+    {
+        $stack = new Pipeline();
+
+        $stack->pass('')
+            ->through(new AfterMiddleware)
+            ->through(new BeforeMiddleware);
+
+        $this->assertEquals('hello world', $stack->run());
+    }
+
+    public function testStackConstructedWithMiddleware()
+    {
+        $stack = new Pipeline([
+            new BeforeMiddleware,
+            new AfterMiddleware
+        ]);
+
+        $this->assertEquals('hello world', $stack->pass('')->run());
+    }
+}

--- a/tests/Mock/AfterMiddleware.php
+++ b/tests/Mock/AfterMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Mock;
+
+use HelloFresh\Engine\Middleware\MiddlewareInterface;
+
+class AfterMiddleware implements MiddlewareInterface
+{
+    public function handle($passable, $next)
+    {
+        $result = $next($passable);
+
+        $result .= ' world';
+
+        return $result;
+    }
+}

--- a/tests/Mock/BeforeMiddleware.php
+++ b/tests/Mock/BeforeMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Mock;
+
+use HelloFresh\Engine\Middleware\MiddlewareInterface;
+
+class BeforeMiddleware implements MiddlewareInterface
+{
+    public function handle($passable, $next)
+    {
+        $passable = 'hello' . $passable;
+
+        return $next($passable);
+    }
+}


### PR DESCRIPTION
# What this PR changes:
- Adds a middleware pipeline and middleware interface
- This allows us to write middleware (such as loggers) for different tasks (such as event dispatches) whilst keeping separation of concerns.
- Supports before and after middleware
# When reviewing, please consider:
- The tests feel a little incomplete, any suggestions on a few more would be good.
