### PR TITLE
Issue/microseconds

### DIFF
--- a/src/Domain/DomainMessage.php
+++ b/src/Domain/DomainMessage.php
@@ -28,14 +28,14 @@ final class DomainMessage
     private $version;
 
     /**
-     * @param string $id
+     * @param AggregateIdInterface|string $id
      * @param $version
      * @param mixed $payload
      * @param \DateTimeImmutable $recordedOn
      */
     public function __construct($id, $version, $payload, \DateTimeImmutable $recordedOn)
     {
-        $this->id = $id;
+        $this->id = (string) $id;
         $this->payload = $payload;
         $this->recordedOn = $recordedOn->setTimezone(new \DateTimeZone('UTC'));
         $this->version = $version;
@@ -58,7 +58,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getRecordedOn()
     {
@@ -66,7 +66,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getType()
     {

--- a/src/Domain/DomainMessage.php
+++ b/src/Domain/DomainMessage.php
@@ -37,12 +37,12 @@ final class DomainMessage
     {
         $this->id = $id;
         $this->payload = $payload;
-        $this->recordedOn = $recordedOn;
+        $this->recordedOn = $recordedOn->setTimezone(new \DateTimeZone('UTC'));
         $this->version = $version;
     }
 
     /**
-     * @return AggregateIdInterface
+     * @return string
      */
     public function getId()
     {
@@ -81,7 +81,9 @@ final class DomainMessage
      */
     public static function recordNow($id, $version, DomainEventInterface $payload)
     {
-        return new DomainMessage($id, $version, $payload, new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        $recordedOn = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+
+        return new DomainMessage($id, $version, $payload, $recordedOn);
     }
 
     /**

--- a/src/EventStore/Adapter/RedisAdapter.php
+++ b/src/EventStore/Adapter/RedisAdapter.php
@@ -59,8 +59,8 @@ class RedisAdapter implements EventStoreAdapterInterface
         return count($this->redis->lrange($this->getNamespaceKey($streamName, $aggregateId), 0, -1));
     }
 
-    private function getNamespaceKey(StreamName $streamName, AggregateIdInterface $aggregateId)
+    private function getNamespaceKey(StreamName $streamName, $aggregateId)
     {
-        return "events:{$streamName}:{$aggregateId}";
+        return sprintf('events:%s:%s', $streamName, $aggregateId);
     }
 }

--- a/src/EventStore/Snapshot/Snapshot.php
+++ b/src/EventStore/Snapshot/Snapshot.php
@@ -43,7 +43,7 @@ class Snapshot
         $this->aggregateId = $aggregateId;
         $this->aggregate = $aggregate;
         $this->version = $version;
-        $this->createdAt = $createdAt;
+        $this->createdAt = $createdAt->setTimezone(new \DateTimeZone('UTC'));
     }
 
     /**
@@ -55,7 +55,9 @@ class Snapshot
      */
     public static function take(AggregateIdInterface $aggregateId, AggregateRootInterface $aggregate, $version)
     {
-        return new static($aggregateId, $aggregate, $version, new \DateTimeImmutable());
+        $dateTime = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+
+        return new static($aggregateId, $aggregate, $version, $dateTime);
     }
 
     /**

--- a/tests/Domain/DomainMessageTest.php
+++ b/tests/Domain/DomainMessageTest.php
@@ -24,8 +24,9 @@ class DomainMessageTest extends \PHPUnit_Framework_TestCase
         \DateTimeImmutable $date
     ) {
         $message = new DomainMessage($aggregateId, $version, $payload, $date);
+
         $this->assertInstanceOf(DomainMessage::class, $message);
-        $this->assertSame($aggregateId, $message->getId());
+        $this->assertSame((string) $aggregateId, $message->getId());
         $this->assertSame($version, $message->getVersion());
         $this->assertSame($payload, $message->getPayload());
         $this->assertEquals($date, $message->getRecordedOn());
@@ -47,6 +48,7 @@ class DomainMessageTest extends \PHPUnit_Framework_TestCase
         \DateTimeImmutable $date
     ) {
         $message = DomainMessage::recordNow($aggregateId, $version, $payload);
+
         $this->assertInstanceOf(DomainMessage::class, $message);
 
         $this->assertNotEmpty((int)$message->getRecordedOn()->format('u'), 'Expected microseconds to be set');

--- a/tests/Domain/DomainMessageTest.php
+++ b/tests/Domain/DomainMessageTest.php
@@ -25,10 +25,11 @@ class DomainMessageTest extends \PHPUnit_Framework_TestCase
     ) {
         $message = new DomainMessage($aggregateId, $version, $payload, $date);
         $this->assertInstanceOf(DomainMessage::class, $message);
-        $this->assertEquals($aggregateId, $message->getId());
-        $this->assertEquals($version, $message->getVersion());
-        $this->assertEquals($payload, $message->getPayload());
+        $this->assertSame($aggregateId, $message->getId());
+        $this->assertSame($version, $message->getVersion());
+        $this->assertSame($payload, $message->getPayload());
         $this->assertEquals($date, $message->getRecordedOn());
+        $this->assertEquals(new \DateTimeZone('UTC'), $message->getRecordedOn()->getTimezone());
     }
 
     /**
@@ -47,6 +48,9 @@ class DomainMessageTest extends \PHPUnit_Framework_TestCase
     ) {
         $message = DomainMessage::recordNow($aggregateId, $version, $payload);
         $this->assertInstanceOf(DomainMessage::class, $message);
+
+        $this->assertNotEmpty((int)$message->getRecordedOn()->format('u'), 'Expected microseconds to be set');
+        $this->assertEquals(new \DateTimeZone('UTC'), $message->getRecordedOn()->getTimezone());
     }
 
     public function messageProvider()
@@ -54,7 +58,13 @@ class DomainMessageTest extends \PHPUnit_Framework_TestCase
         return [
             [AggregateId::generate(), 1, new SomethingHappened(), new \DateTimeImmutable()],
             [AggregateId::generate(), 100, new SomethingHappened(), new \DateTimeImmutable()],
-            [AggregateId::generate(), 9999999, new SomethingHappened(), new \DateTimeImmutable()]
+            [AggregateId::generate(), 9999999, new SomethingHappened(), new \DateTimeImmutable()],
+            [
+                AggregateId::generate(),
+                9999999,
+                new SomethingHappened(),
+                \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true)))
+            ]
         ];
     }
 }

--- a/tests/EventStore/EventStoreTest.php
+++ b/tests/EventStore/EventStoreTest.php
@@ -3,6 +3,7 @@
 namespace HelloFresh\Tests\Engine\EventStore;
 
 use HelloFresh\Engine\Domain\AggregateId;
+use HelloFresh\Engine\Domain\AggregateIdInterface;
 use HelloFresh\Engine\Domain\DomainMessage;
 use HelloFresh\Engine\Domain\EventStream;
 use HelloFresh\Engine\Domain\StreamName;
@@ -79,7 +80,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'Simple String' => [
-                'Yolntbyaac', //You only live nine times because you are a cat
+                'Yolntbyaac', // You only live nine times because you are a cat
             ],
             'Identitiy' => [
                 AggregateId::generate(),

--- a/tests/EventStore/Snapshot/Adapter/RedisSnapshotAdapterTest.php
+++ b/tests/EventStore/Snapshot/Adapter/RedisSnapshotAdapterTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\EventStore\Snapshot\Adapter;
+
+use HelloFresh\Engine\Domain\AggregateId;
+use HelloFresh\Engine\EventStore\Snapshot\Adapter\RedisSnapshotAdapter;
+use HelloFresh\Engine\EventStore\Snapshot\Snapshot;
+use HelloFresh\Engine\Serializer\SerializerInterface;
+use HelloFresh\Tests\Engine\Mock\AggregateRoot;
+use HelloFresh\Tests\Engine\Mock\PredisClient;
+use PHPUnit\Framework\TestCase;
+use Predis\ClientInterface;
+
+class RedisSnapshotAdapterTest extends TestCase
+{
+    /**
+     * @var ClientInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $client;
+    /**
+     * @var SerializerInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $serializer;
+
+    protected function setUp()
+    {
+        $this->client = $this->prophesize(PredisClient::class);
+        $this->serializer = $this->prophesize(SerializerInterface::class);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanSaveASnapshot()
+    {
+        $id = AggregateId::generate();
+        $aggregate = AggregateRoot::create($id, 'test');
+
+        $snapshot = Snapshot::take($id, $aggregate, '10');
+
+        $expectedSerializedAggregate = sprintf('["serialized": "%s"]', spl_object_hash($snapshot));
+        $expectedStorageArray = [
+            'version' => '10',
+            'created_at' => $snapshot->getCreatedAt()->format('U.u'),
+            'snapshot' => [
+                'type' => AggregateRoot::class,
+                'payload' => $expectedSerializedAggregate,
+            ]
+        ];
+        $expectedStoredData = '["version etc..."]';
+
+        $this->serializer->serialize($aggregate, 'json')
+            ->willReturn($expectedSerializedAggregate)
+            ->shouldBeCalledTimes(1);
+        $this->serializer->serialize($expectedStorageArray, 'json')
+            ->willReturn($expectedStoredData)
+            ->shouldBeCalledTimes(1);
+
+        $this->client->hset(RedisSnapshotAdapter::KEY_NAMESPACE, (string)$id, $expectedStoredData)
+            ->shouldBeCalledTimes(1);
+
+        $adapter = $this->createAdapter();
+        $adapter->save($snapshot);
+    }
+
+    /**
+     * @test
+     */
+    public function aSnapshotCanBeRetrievedById()
+    {
+        $id = AggregateId::generate();
+
+        $expectedAggregate = AggregateRoot::create($id, 'testing');
+
+        $snapshotMetadata = [
+            'version' => '15',
+            'created_at' => '1468847497.332610',
+            'snapshot' => [
+                'type' => AggregateRoot::class,
+                'payload' => 'aggregate_data',
+            ]
+        ];
+
+        $this->mockRedisHasAndGetData($id, $snapshotMetadata);
+
+        $this->serializer->deserialize('aggregate_data', AggregateRoot::class, 'json')
+            ->willReturn($expectedAggregate);
+
+        $adapter = $this->createAdapter();
+        $result = $adapter->byId($id);
+
+        $this->assertInstanceOf(Snapshot::class, $result);
+        $this->assertSame($id, $result->getAggregateId());
+        $this->assertSame($expectedAggregate, $result->getAggregate());
+        $this->assertSame('15', $result->getVersion());
+        $this->assertSame('1468847497.332610', $result->getCreatedAt()->format('U.u'));
+        $this->assertEquals(new \DateTimeZone('UTC'), $result->getCreatedAt()->getTimezone());
+    }
+
+    /**
+     * @test
+     */
+    public function aSnapshotCanNotBeRetrievedWhenTheIdIsUnknown()
+    {
+        $id = AggregateId::generate();
+
+        $this->client->hexists(RedisSnapshotAdapter::KEY_NAMESPACE, (string)$id)
+            ->willReturn(false)
+            ->shouldBeCalledTimes(1);
+
+        $adapter = $this->createAdapter();
+        $result = $adapter->byId($id);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function itIndicatedIfASnapshotOfAggregateWithVersionExists()
+    {
+        $id = AggregateId::generate();
+        $expectedDeserializedRedisData = ['version' => 20];
+
+        $this->mockRedisHasAndGetData($id, $expectedDeserializedRedisData);
+
+        $adapter = $this->createAdapter();
+        $result = $adapter->has($id, 20);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function itIndicatedThatASnapshotOfAggregateIsUnknown()
+    {
+        $id = AggregateId::generate();
+
+        $this->client->hexists(RedisSnapshotAdapter::KEY_NAMESPACE, (string)$id)
+            ->willReturn(false)
+            ->shouldBeCalledTimes(1);
+
+        $adapter = $this->createAdapter();
+        $result = $adapter->has($id, 15);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function itIndicatedThatASnapshotOfAggregateIsUnknownWhenTheVersionIsIncorrect()
+    {
+        $id = AggregateId::generate();
+
+        $this->mockRedisHasAndGetData($id, 20);
+
+        $adapter = $this->createAdapter();
+        $result = $adapter->has($id, 15);
+
+        $this->assertFalse($result);
+    }
+
+
+    /**
+     * @return RedisSnapshotAdapter
+     */
+    protected function createAdapter()
+    {
+        $adapter = new RedisSnapshotAdapter($this->client->reveal(), $this->serializer->reveal());
+        return $adapter;
+    }
+
+    /**
+     * @param $id
+     * @param $expectedDeserializedRedisData
+     */
+    protected function mockRedisHasAndGetData($id, $expectedDeserializedRedisData)
+    {
+        $this->client->hexists(RedisSnapshotAdapter::KEY_NAMESPACE, (string)$id)
+            ->willReturn(true)
+            ->shouldBeCalledTimes(1);
+
+        $this->client->hget(RedisSnapshotAdapter::KEY_NAMESPACE, (string)$id)
+            ->willReturn('redis_data')
+            ->shouldBeCalledTimes(1);
+
+        $this->serializer->deserialize('redis_data', 'array', 'json')
+            ->willReturn($expectedDeserializedRedisData);
+    }
+}

--- a/tests/EventStore/Snapshot/SnapshotTest.php
+++ b/tests/EventStore/Snapshot/SnapshotTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\EventStore\Snapshot;
+
+use HelloFresh\Engine\Domain\AggregateId;
+use HelloFresh\Engine\Domain\AggregateIdInterface;
+use HelloFresh\Engine\Domain\AggregateRootInterface;
+use HelloFresh\Engine\EventStore\Snapshot\Snapshot;
+use HelloFresh\Tests\Engine\Mock\AggregateRoot;
+use PHPUnit\Framework\TestCase;
+
+class SnapshotTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider messageProvider
+     * @param AggregateIdInterface $aggregateId
+     * @param AggregateRootInterface $aggregate
+     * @param $version
+     * @param \DateTimeImmutable $date
+     * @internal param $payload
+     */
+    public function itShouldCreateASnapshotFromConstructor(
+        AggregateIdInterface $aggregateId,
+        AggregateRootInterface $aggregate,
+        $version,
+        \DateTimeImmutable $date
+    ) {
+        $message = new Snapshot($aggregateId, $aggregate, $version, $date);
+
+        $this->assertInstanceOf(Snapshot::class, $message);
+        $this->assertSame($aggregateId, $message->getAggregateId());
+        $this->assertSame($aggregate, $message->getAggregate());
+        $this->assertSame($version, $message->getVersion());
+        $this->assertSame(get_class($aggregate), $message->getType());
+        $this->assertEquals($date, $message->getCreatedAt());
+        $this->assertEquals(new \DateTimeZone('UTC'), $message->getCreatedAt()->getTimezone());
+    }
+
+    /**
+     * @test
+     * @dataProvider messageProvider
+     * @param AggregateIdInterface $aggregateId
+     * @param AggregateRootInterface $aggregate
+     * @param string $version
+     */
+    public function itShouldCreateASnapshotFromNamedConstructor(
+        AggregateIdInterface $aggregateId,
+        AggregateRootInterface $aggregate,
+        $version
+    ) {
+        $snapshot = Snapshot::take($aggregateId, $aggregate, $version);
+
+        $this->assertInstanceOf(Snapshot::class, $snapshot);
+        $this->assertNotEmpty((int)$snapshot->getCreatedAt()->format('u'), 'Expected microseconds to be set');
+        $this->assertEquals(new \DateTimeZone('UTC'), $snapshot->getCreatedAt()->getTimezone());
+    }
+
+    public function messageProvider()
+    {
+        return [
+            [
+                AggregateId::generate(),
+                AggregateRoot::create(AggregateId::generate(), 'v1000'),
+                '1000',
+                new \DateTimeImmutable()
+            ],
+            [
+                AggregateId::generate(),
+                AggregateRoot::create(AggregateId::generate(), 'v1'),
+                '1',
+                \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true)))
+            ]
+        ];
+    }
+}

--- a/tests/Mock/PredisClient.php
+++ b/tests/Mock/PredisClient.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace HelloFresh\Tests\Engine\Mock;
+
+use Predis\ClientInterface;
+
+/**
+ * A custom predis client mock with some of the magic methods added so prophecy can play nice and not mice.
+ */
+abstract class PredisClient implements ClientInterface
+{
+    abstract public function hset($key, $field, $value);
+
+    abstract public function hexists($key, $field);
+
+    abstract public function hget($key, $field);
+}


### PR DESCRIPTION
# What this PR changes:
- This PR fixes a bug where DomainMessage recordedOn and Snapshot CreatedOn DateTime values are saved with only seconds and not microseconds. 
  In some cases this behavior could cause problems for systems witch handle multiple writes within a second.
- This also fix a issue where the DomainMessage::getId will now always be a string
