### PR TITLE
[IMR-927]: Bump beberlei/assert so that we can update dependencies in products-service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ services:
   - postgresql
 
 php:
-  - 5.6
   - 7.0
   - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "type": "library",
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "ramsey/uuid": "^3.0",
     "easyframework/collections": "^7.0.0",
-    "beberlei/assert": "^2.5"
+    "beberlei/assert": "^3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.3",


### PR DESCRIPTION
## Ticket

- https://hellofresh.atlassian.net/browse/IMR-927

## Description

We want to update the dependencies for `products-service`. Unfortunately, I need to update this first

This change is safe, I already cross checked the dependencies of `beberlei/assert`. Also checked the usage in this project, we only use it 1 place

![image](https://user-images.githubusercontent.com/1154587/63033845-971c8780-beb8-11e9-86bf-7c04bde33484.png)

## References
- https://github.com/hellofresh/products-service/pull/440
- https://github.com/hellofresh/chassis-engine/pull/88